### PR TITLE
ci(actions): Change actions/checkout version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,14 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout Bucket
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
         with:
           fetch-depth: 2
           path: 'my_bucket'
       - name: Checkout Scoop
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
         with:
           repository: ScoopInstaller/Scoop
-          ref: develop
           path: 'scoop_core'
       - name: Init and Test
         shell: powershell
@@ -32,15 +31,14 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout Bucket
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
         with:
           fetch-depth: 2
           path: 'my_bucket'
       - name: Checkout Scoop
-        uses: actions/checkout@v2
+        uses: actions/checkout@main
         with:
           repository: ScoopInstaller/Scoop
-          ref: develop
           path: 'scoop_core'
       - name: Init and Test
         shell: pwsh


### PR DESCRIPTION
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Relates to https://github.com/ScoopInstaller/GithubActions/issues/21

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
