### PR TITLE
(chore): Use PSModuleCache to install BuildHelpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: Tests
 
 on:
   pull_request:
-  push:
   workflow_dispatch:
 
 jobs:
@@ -21,11 +20,15 @@ jobs:
           repository: ScoopInstaller/Scoop
           ref: develop
           path: 'scoop_core'
-      - name: Init and Test
+      - name: Init Test Suite
+        uses: potatoqualitee/psmodulecache@v5.1
+        with:
+          modules-to-cache: BuildHelpers
+          shell: powershell
+      - name: Test Bucket
         shell: powershell
         run: |
           $env:SCOOP_HOME="$(Convert-Path '.\scoop_core')"
-          .\scoop_core\test\bin\init.ps1
           .\my_bucket\bin\test.ps1
   test_pwsh:
     name: PowerShell
@@ -42,9 +45,13 @@ jobs:
           repository: ScoopInstaller/Scoop
           ref: develop
           path: 'scoop_core'
-      - name: Init and Test
+      - name: Init Test Suite
+        uses: potatoqualitee/psmodulecache@v5.1
+        with:
+          modules-to-cache: BuildHelpers
+          shell: pwsh
+      - name: Test Bucket
         shell: pwsh
         run: |
           $env:SCOOP_HOME="$(Convert-Path '.\scoop_core')"
-          .\scoop_core\test\bin\init.ps1
           .\my_bucket\bin\test.ps1

--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -1,4 +1,5 @@
 #Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'BuildHelpers'; ModuleVersion = '2.0.1' }
 #Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.2.0' }
 
 $pesterConfig = New-PesterConfiguration -Hashtable @{


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to https://github.com/ScoopInstaller/Scoop/pull/5226

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
